### PR TITLE
truncate outcome names

### DIFF
--- a/public/javascripts/chart.js
+++ b/public/javascripts/chart.js
@@ -26,7 +26,8 @@ function drawChart(nodeInfoArray, divSelect)
 	var nodeOutcomes = nodeInfoArray["values"];
 	var i;
 	for (i=0; i<nodeOutcomes.length; i++) {
-		outcomes.push((nodeOutcomes[i])["outcomeid"]);
+		outcomes.push(truncateOutcome((nodeOutcomes[i])["outcomeid"]));
+		//outcomes.push((nodeOutcomes[i])["outcomeid"]);
 		data.push((nodeOutcomes[i])["value"]);
 	}
 	

--- a/public/javascripts/model.js
+++ b/public/javascripts/model.js
@@ -265,7 +265,7 @@ function getCPT(nodeID)
 	$.ajax({
 		url: getCPTAjax.url
 	}).done(function(data) {
-		console.log(data);
+		//console.log(data);
 		var cpt = JSON.parse(data);
 
 		var columnrenderer = function (value) {
@@ -281,9 +281,9 @@ function getCPT(nodeID)
 			}
 			var columnTitles = [];
 			var count = 0;
-			for (i = 0; i<titles.length; i++) {
+			for (var i = 0; i<titles.length; i++) {
 				for (j = 0; j<parents[0].outcomeIDs.length; j++) {
-					var title =  titles[i] + '<br>' + parents[0].parentName + ': ' + parents[0].outcomeIDs[j];
+					var title =  titles[i] + '<br>' + parents[0].parentName + ': ' + truncateOutcome(parents[0].outcomeIDs[j]);
 					columnTitles[count] = title;
 					columnStruct[i] = { text: title, renderer: columnrenderer, datafield: title, width: widthSize };
 					count ++;
@@ -298,8 +298,8 @@ function getCPT(nodeID)
 		var columnStruct = [];
 		if (parents.length > 0) {
 			var titles = [];
-			for (i = 0; i < parents[0].outcomeIDs.length; i++){
-				var title = parents[0].parentName + ': ' + parents[0].outcomeIDs[i];
+			for (var i = 0; i < parents[0].outcomeIDs.length; i++){
+				var title = parents[0].parentName + ': ' + truncateOutcome(parents[0].outcomeIDs[i]);
 				titles[i] = title;
 				columnStruct[i] = { text: titles[i], renderer: columnrenderer, datafield: titles[i], width: widthSize };
 			}
@@ -316,9 +316,9 @@ function getCPT(nodeID)
 		var defIter = 0;
 		var start = 0;
 		var numOutcomes = cpt.outcomeIDs.length;
-		for (i = 0; i < numOutcomes; i++) {
+		for (var i = 0; i < numOutcomes; i++) {
 			data[i] = {};
-			data[i]["rowTitle"] = cpt.outcomeIDs[i];
+			data[i]["rowTitle"] = truncateOutcome(cpt.outcomeIDs[i]);
 			for (j = 0; j < columnTitles.length; j++) {
 				data[i][columnTitles[j]] = cpt.definition[defIter];
 				defIter = defIter + numOutcomes;

--- a/public/javascripts/viewer.js
+++ b/public/javascripts/viewer.js
@@ -11,7 +11,7 @@ $(document).ready(function () {
    
    $('#dialogSetValues').jqxWindow({  width: 600,
        height: 400, resizable: true,
-       okButton: $('#doneButton'),
+       okButton: $('#doneButton'), autoOpen: false,
        initContent: function () {
            $("#dialogGeneralPanel").jqxPanel({ width: 590, height: 300});
            $("#dialogSetEvidencePanel").jqxPanel({ width: 590, height: 300});
@@ -78,8 +78,8 @@ function nodeSelected(nodeID, nodeName)
 	var i;
 	for (i=0; i<nodeOutcomes[0].values.length; i++) {
 		//$form.append(nodeOutcomes[0].values[i].outcomeid + ": ");
-		$form.append('<input name="outcomeids" type="radio" value="' + nodeOutcomes[0].values[i].outcomeid + '" />' + nodeOutcomes[0].values[i].outcomeid + '<br>');
-		$formVirtual.append(nodeOutcomes[0].values[i].outcomeid + ': <input name="voutcomeids" type="text" value="' + nodeOutcomes[0].values[i].value + '"/><br>');
+		$form.append('<input name="outcomeids" type="radio" value="' + nodeOutcomes[0].values[i].outcomeid + '" />' + truncateOutcome(nodeOutcomes[0].values[i].outcomeid) + '<br>');
+		$formVirtual.append(truncateOutcome(nodeOutcomes[0].values[i].outcomeid) + ': <input name="voutcomeids" type="text" value="' + nodeOutcomes[0].values[i].value + '"/><br>');
 	}
 	
 	$("#dialogSetEvidencePanel #formDiv").append($form);
@@ -88,4 +88,20 @@ function nodeSelected(nodeID, nodeName)
 	$('#dialogSetValues').jqxWindow('open');
 
 	getCPT(nodeID);
+}
+
+function truncateOutcome(name)
+{
+	var maxLength = 10;
+	var truncated;
+	if (name.length > maxLength) {
+		truncated = name.substring(0,maxLength);
+	}
+	else {
+		truncated = name;
+		for (var i=name.length; i<maxLength; i++) {
+			truncated = truncated.concat(" ");
+		}
+	}
+	return truncated;
 }


### PR DESCRIPTION
Problem: In our network, there is not outcome Name, there is only outcome ID and it's outcome value.
Solution: I created a function to truncate the outcome ID. This function has to be called before visualizing the outcome ID.

Still an issue: Font is set as Helvetica, which is not monospaced and therefore charts are not as even. 

Ideas: Instead of adding spaces to short outcome IDs, we could add "..." at the end to indicate the truncation.
